### PR TITLE
get_open_items_for_user_db adopted

### DIFF
--- a/lambda_functions/crud/model.py
+++ b/lambda_functions/crud/model.py
@@ -266,6 +266,7 @@ class Review(Base):
     peer_review_id = Column(String(36))
     belongs_to_good_pair = Column(Boolean)
     user_id = Column(String(36), ForeignKey('users.id'))
+    item_id = Column(String(36), ForeignKey('items.id'))
     start_timestamp = Column(DateTime)
     finish_timestamp = Column(DateTime)
     status = Column(String(100))

--- a/lambda_functions/crud/model.py
+++ b/lambda_functions/crud/model.py
@@ -28,6 +28,7 @@ class Item(Base):
     urls = relationship("ItemURL")
     sentiments = relationship("ItemSentiment")
     keyphrases = relationship("ItemKeyphrase")
+    reviews = relationship("Review", back_populates="item")
     review_pairs = relationship("ReviewPair", back_populates="item")
 
     def to_dict(self):
@@ -272,6 +273,7 @@ class Review(Base):
     status = Column(String(100))
 
     review_answers = relationship("ReviewAnswer", back_populates="review")
+    item = relationship("Item", back_populates="reviews")
 
     def to_dict(self):
         return {"id": self.id, "is_peer_review": self.is_peer_review, "peer_review_id": self.peer_review_id,

--- a/lambda_functions/crud/operations.py
+++ b/lambda_functions/crud/operations.py
@@ -583,7 +583,6 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
         .filter(~Item.reviews.any(Review.user_id == user.id)) \
         .order_by(Item.open_timestamp.asc()) \
         .limit(num_items).all()
-#        .filter(~Item.review_pairs.any(and_(Review.item_id == Item.id, Review.user_id == user.id))) \
 
     for item in result:
         items.append(item)

--- a/lambda_functions/crud/operations.py
+++ b/lambda_functions/crud/operations.py
@@ -572,6 +572,7 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
             .order_by(Item.open_timestamp.asc()) \
             .limit(num_items).all()
 
+        # If open items are available, return them
         if len(result) > 0:
             for item in result:
                 items.append(item)

--- a/lambda_functions/crud/operations.py
+++ b/lambda_functions/crud/operations.py
@@ -14,7 +14,7 @@ from crud.model import (
     Item, ItemEntity, ItemKeyphrase, ItemSentiment, ItemURL, Keyphrase, Review,
     ReviewAnswer, ReviewQuestion, Sentiment, Submission,
     User, Level, ReviewPair)
-from sqlalchemy import create_engine, or_, and_
+from sqlalchemy import create_engine, or_
 from sqlalchemy.orm import Session, backref, relationship, sessionmaker
 
 from . import helper, notifications
@@ -572,10 +572,11 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
             .order_by(Item.open_timestamp.asc()) \
             .limit(num_items).all()
 
-        for item in result:
-            items.append(item)
-        random.shuffle(items)
-        return items
+        if len(result) > 0:
+            for item in result:
+                items.append(item)
+            random.shuffle(items)
+            return items
 
     # Get open items for junior review and return them
     result = session.query(Item) \

--- a/lambda_functions/crud/operations.py
+++ b/lambda_functions/crud/operations.py
@@ -568,21 +568,33 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
         # Get open items for senior review
         result = session.query(Item) \
             .filter(Item.open_reviews_level_2 > Item.in_progress_reviews_level_2) \
-            .filter(~Item.reviews.any(Review.user_id == user.id)) \
-            .order_by(Item.open_timestamp.asc()) \
-            .limit(num_items).all()
+            .order_by(Item.open_timestamp.asc())
+        reviews = session.query(Review) \
+            .filter(user.id == Review.user_id)
+
+        # result = session.query(Item) \
+        #     .filter(Item.open_reviews_level_2 > Item.in_progress_reviews_level_2) \
+        #     .filter(~Item.reviews.any(Review.user_id == user.id)) \
+        #     .order_by(Item.open_timestamp.asc()) \
+        #     .limit(num_items).all()
 
         # If open items are available, return them
-        if len(result) > 0:
-            for item in result:
+        for item in result:
+            user_didnt_review = True
+            for review in reviews:
+                if review.item_id == item.id:
+                    user_didnt_review = False
+            if user_didnt_review:
                 items.append(item)
-            random.shuffle(items)
-            return items
+        random.shuffle(items)
+        if len(items)>num_items:
+            items=items[:num_items]
+        return items
 
     # Get open items for junior review and return them
     result = session.query(Item) \
         .filter(Item.open_reviews_level_1 > Item.in_progress_reviews_level_1) \
-        .filter(~Item.reviews.any(Review.user_id == user.id)) \
+        .filter(~Item.review_pairs.any(Review.user_id == user.id)) \
         .order_by(Item.open_timestamp.asc()) \
         .limit(num_items).all()
 

--- a/lambda_functions/crud/operations.py
+++ b/lambda_functions/crud/operations.py
@@ -568,10 +568,10 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
         # Get open items for senior review
         result = session.query(Item) \
             .filter(Item.open_reviews_level_2 > Item.in_progress_reviews_level_2) \
-            .filter(~Item.review_pairs.any(and_(Review.item_id == Item.id, Review.user_id == user.id))) \
+            .filter(~Item.reviews.any(Review.user_id == user.id)) \
             .order_by(Item.open_timestamp.asc()) \
             .limit(num_items).all()
- 
+
         for item in result:
             items.append(item)
         random.shuffle(items)
@@ -580,9 +580,10 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
     # Get open items for junior review and return them
     result = session.query(Item) \
         .filter(Item.open_reviews_level_1 > Item.in_progress_reviews_level_1) \
-        .filter(~Item.review_pairs.any(and_(Review.item_id == Item.id, Review.user_id == user.id))) \
+        .filter(~Item.reviews.any(Review.user_id == user.id)) \
         .order_by(Item.open_timestamp.asc()) \
         .limit(num_items).all()
+#        .filter(~Item.review_pairs.any(and_(Review.item_id == Item.id, Review.user_id == user.id))) \
 
     for item in result:
         items.append(item)

--- a/lambda_functions/crud/operations.py
+++ b/lambda_functions/crud/operations.py
@@ -14,7 +14,7 @@ from crud.model import (
     Item, ItemEntity, ItemKeyphrase, ItemSentiment, ItemURL, Keyphrase, Review,
     ReviewAnswer, ReviewQuestion, Sentiment, Submission,
     User, Level, ReviewPair)
-from sqlalchemy import create_engine, or_
+from sqlalchemy import create_engine, or_, and_
 from sqlalchemy.orm import Session, backref, relationship, sessionmaker
 
 from . import helper, notifications
@@ -568,33 +568,19 @@ def get_open_items_for_user_db(user, num_items, is_test, session):
         # Get open items for senior review
         result = session.query(Item) \
             .filter(Item.open_reviews_level_2 > Item.in_progress_reviews_level_2) \
-            .order_by(Item.open_timestamp.asc())
-        reviews = session.query(Review) \
-            .filter(user.id == Review.user_id)
-
-        # result = session.query(Item) \
-        #     .filter(Item.open_reviews_level_2 > Item.in_progress_reviews_level_2) \
-        #     .filter(~Item.reviews.any(Review.user_id == user.id)) \
-        #     .order_by(Item.open_timestamp.asc()) \
-        #     .limit(num_items).all()
-
-        # If open items are available, return them
+            .filter(~Item.review_pairs.any(and_(Review.item_id == Item.id, Review.user_id == user.id))) \
+            .order_by(Item.open_timestamp.asc()) \
+            .limit(num_items).all()
+ 
         for item in result:
-            user_didnt_review = True
-            for review in reviews:
-                if review.item_id == item.id:
-                    user_didnt_review = False
-            if user_didnt_review:
-                items.append(item)
+            items.append(item)
         random.shuffle(items)
-        if len(items)>num_items:
-            items=items[:num_items]
         return items
 
     # Get open items for junior review and return them
     result = session.query(Item) \
         .filter(Item.open_reviews_level_1 > Item.in_progress_reviews_level_1) \
-        .filter(~Item.review_pairs.any(Review.user_id == user.id)) \
+        .filter(~Item.review_pairs.any(and_(Review.item_id == Item.id, Review.user_id == user.id))) \
         .order_by(Item.open_timestamp.asc()) \
         .limit(num_items).all()
 

--- a/lambda_functions/test/unit/test_GetOpenItemsForUser.py
+++ b/lambda_functions/test/unit/test_GetOpenItemsForUser.py
@@ -7,139 +7,184 @@ import test.unit.event_creator as event_creator
 import test.unit.setup_scenarios as scenarios
 
 
-def test_get_open_items_for_user(monkeypatch):
-    monkeypatch.setenv("DBNAME", "Test")
-    import app
+class TestGetOpenItems:
+    def test_get_open_items_for_user(self, monkeypatch):
+        monkeypatch.setenv("DBNAME", "Test")
+        import app
 
-    session = operations.get_db_session(True, None)
+        session = operations.get_db_session(True, None)
 
-    session = scenarios.create_levels_junior_and_senior_detectives(session)
+        session = scenarios.create_levels_junior_and_senior_detectives(session)
 
-    junior_detective1 = operations.get_user_by_id("1", True, session)
-    junior_detective2 = operations.get_user_by_id("2", True, session)
-    junior_detective3 = operations.get_user_by_id("3", True, session)
-    junior_detective4 = operations.get_user_by_id("4", True, session)
+        junior_detective1 = operations.get_user_by_id("1", True, session)
+        junior_detective2 = operations.get_user_by_id("2", True, session)
+        junior_detective3 = operations.get_user_by_id("3", True, session)
+        junior_detective4 = operations.get_user_by_id("4", True, session)
 
-    senior_detective1 = operations.get_user_by_id("11", True, session)
+        senior_detective1 = operations.get_user_by_id("11", True, session)
 
-    users = operations.get_all_users_db(True, session)
-    assert len(users) == 8
+        users = operations.get_all_users_db(True, session)
+        assert len(users) == 8
 
-    # Creating 5 items
+        # Creating 5 items
 
-    item1 = Item()
-    item1.content = "Item 1"
-    item1 = operations.create_item_db(item1, True, session)
+        item1 = Item()
+        item1.content = "Item 1"
+        item1 = operations.create_item_db(item1, True, session)
 
-    item2 = Item()
-    item2.content = "Item 2"
-    item2 = operations.create_item_db(item2, True, session)
+        item2 = Item()
+        item2.content = "Item 2"
+        item2 = operations.create_item_db(item2, True, session)
 
-    item3 = Item()
-    item3.content = "Item 3"
-    item3 = operations.create_item_db(item3, True, session)
+        item3 = Item()
+        item3.content = "Item 3"
+        item3 = operations.create_item_db(item3, True, session)
 
-    item4 = Item()
-    item4.content = "Item 4"
-    item4 = operations.create_item_db(item4, True, session)
+        item4 = Item()
+        item4.content = "Item 4"
+        item4 = operations.create_item_db(item4, True, session)
 
-    item5 = Item()
-    item5.content = "Item 5"
-    item5 = operations.create_item_db(item5, True, session)
+        item5 = Item()
+        item5.content = "Item 5"
+        item5 = operations.create_item_db(item5, True, session)
 
-    items = operations.get_all_items_db(True, session)
-    assert len(items) == 5
+        items = operations.get_all_items_db(True, session)
+        assert len(items) == 5
 
-    open_items_for_senior = operations.get_open_items_for_user_db(
-        senior_detective1, 5, True, session)
-    assert len(open_items_for_senior) == 5
+        open_items_for_senior = operations.get_open_items_for_user_db(
+            senior_detective1, 5, True, session)
+        assert len(open_items_for_senior) == 5
 
-    open_items_for_junior = operations.get_open_items_for_user_db(
-        junior_detective1, 5, True, session)
-    assert len(open_items_for_junior) == 5
+        open_items_for_junior = operations.get_open_items_for_user_db(
+            junior_detective1, 5, True, session)
+        assert len(open_items_for_junior) == 5
 
-    # JuniorDetective 1 accepting item 1
-    accept_event = event_creator.get_accept_event(
-        junior_detective1.id, item1.id)
-    app.accept_item(accept_event, None, True, session)
-    open_item_after_accept = operations.get_open_items_for_user_db(
-        junior_detective1, 5, True, session)
-    assert len(open_item_after_accept) == 1
+        # JuniorDetective 1 accepting item 1
+        accept_event = event_creator.get_create_review_event(
+            junior_detective1.id, item1.id)
+        app.create_review(accept_event, None, True, session)
+        open_item_after_accept = operations.get_open_items_for_user_db(
+            junior_detective1, 5, True, session)
+        assert len(open_item_after_accept) == 1
 
-    item1 = operations.get_item_by_id(item1.id, True, session)
-    assert item1.in_progress_reviews_level_1 == 1
+        item1 = operations.get_item_by_id(item1.id, True, session)
+        assert item1.in_progress_reviews_level_1 == 1
 
-    # Accepting event again
-    app.accept_item(accept_event, None, True, session)
-    item1 = operations.get_item_by_id(item1.id, True, session)
-    assert item1.in_progress_reviews_level_1 == 1
+        # Accepting event again
+        app.create_review(accept_event, None, True, session)
+        item1 = operations.get_item_by_id(item1.id, True, session)
+        assert item1.in_progress_reviews_level_1 == 1
 
-    # JuniorDetective 1 finishing review
-    review_event = event_creator.get_review_event(
-        item1.id, junior_detective1.id, 1)
-    app.submit_review(review_event, None, True, session)
+        # JuniorDetective 1 finishing review
+        review_event = event_creator.get_review_event(
+            item1.id, junior_detective1.id, 1)
+        app.submit_review(review_event, None, True, session)
 
-    # For JuniorDetective1 only 4 cases should be available
-    open_items_after_submission = operations.get_open_items_for_user_db(
-        junior_detective1, 5, True, session)
-    assert len(open_items_after_submission) == 4
+        # For JuniorDetective1 only 4 cases should be available
+        open_items_after_submission = operations.get_open_items_for_user_db(
+            junior_detective1, 5, True, session)
+        assert len(open_items_after_submission) == 4
 
-    open_items_limit_3 = operations.get_open_items_for_user_db(
-        junior_detective1, 3, True, session)
-    assert len(open_items_limit_3) == 3
+        open_items_limit_3 = operations.get_open_items_for_user_db(
+            junior_detective1, 3, True, session)
+        assert len(open_items_limit_3) == 3
 
-    open_items_after_other_review = operations.get_open_items_for_user_db(
-        junior_detective4, 5, True, session)
-    assert len(open_items_after_other_review) == 5
+        open_items_after_other_review = operations.get_open_items_for_user_db(
+            junior_detective4, 5, True, session)
+        assert len(open_items_after_other_review) == 5
 
-    # 3 Junior Detectives reviewing Item 2
-    accept_event = event_creator.get_accept_event(
-        junior_detective1.id, item2.id)
-    app.accept_item(accept_event, None, True, session)
+        # 3 Junior Detectives reviewing Item 2
+        accept_event = event_creator.get_create_review_event(
+            junior_detective1.id, item2.id)
+        app.create_review(accept_event, None, True, session)
 
-    accept_event = event_creator.get_accept_event(
-        junior_detective2.id, item2.id)
-    app.accept_item(accept_event, None, True, session)
+        accept_event = event_creator.get_create_review_event(
+            junior_detective2.id, item2.id)
+        app.create_review(accept_event, None, True, session)
 
-    accept_event = event_creator.get_accept_event(
-        junior_detective3.id, item2.id)
-    app.accept_item(accept_event, None, True, session)
+        accept_event = event_creator.get_create_review_event(
+            junior_detective3.id, item2.id)
+        app.create_review(accept_event, None, True, session)
 
-    review_event = event_creator.get_review_event(
-        item2.id, junior_detective1.id, 1)
-    app.submit_review(review_event, None, True, session)
+        review_event = event_creator.get_review_event(
+            item2.id, junior_detective1.id, 1)
+        app.submit_review(review_event, None, True, session)
 
-    review_event = event_creator.get_review_event(
-        item2.id, junior_detective2.id, 1)
-    app.submit_review(review_event, None, True, session)
+        review_event = event_creator.get_review_event(
+            item2.id, junior_detective2.id, 1)
+        app.submit_review(review_event, None, True, session)
 
-    review_event = event_creator.get_review_event(
-        item2.id, junior_detective3.id, 1)
-    app.submit_review(review_event, None, True, session)
+        review_event = event_creator.get_review_event(
+            item2.id, junior_detective3.id, 1)
+        app.submit_review(review_event, None, True, session)
 
-    # 4 Cases should be available for Detective 4
+        # 4 Cases should be available for Detective 4
 
-    open_items_after_other_review = operations.get_open_items_for_user_db(
-        junior_detective4, 5, True, session)
-    assert len(open_items_after_other_review) == 4
+        open_items_after_other_review = operations.get_open_items_for_user_db(
+            junior_detective4, 5, True, session)
+        assert len(open_items_after_other_review) == 4
 
-    open_items_for_senior = operations.get_open_items_for_user_db(
-        senior_detective1, 5, True, session)
-    assert len(open_items_for_senior) == 5
+        open_items_for_senior = operations.get_open_items_for_user_db(
+            senior_detective1, 5, True, session)
+        assert len(open_items_for_senior) == 5
 
-    accept_event = event_creator.get_accept_event(
-        senior_detective1.id, item1.id)
-    app.accept_item(accept_event, None, True, session)
+        accept_event = event_creator.get_create_review_event(
+            senior_detective1.id, item1.id)
+        app.create_review(accept_event, None, True, session)
 
-    open_item_after_accept = operations.get_open_items_for_user_db(
-        senior_detective1, 5, True, session)
-    assert len(open_item_after_accept) == 1
+        open_item_after_accept = operations.get_open_items_for_user_db(
+            senior_detective1, 5, True, session)
+        assert len(open_item_after_accept) == 1
 
-    review_event = event_creator.get_review_event(
-        item1.id, senior_detective1.id, 1)
-    app.submit_review(review_event, None, True, session)
+        review_event = event_creator.get_review_event(
+            item1.id, senior_detective1.id, 1)
+        app.submit_review(review_event, None, True, session)
 
-    # For SeniorDetective1 only 4 cases should be available
-    open_items_after_submission = operations.get_open_items_for_user_db(
-        senior_detective1, 5, True, session)
-    assert len(open_items_after_submission) == 4
+        # For SeniorDetective1 only 4 cases should be available
+        open_items_after_submission = operations.get_open_items_for_user_db(
+            senior_detective1, 5, True, session)
+        assert len(open_items_after_submission) == 4
+
+        # SeniorDetective 1 accepting item 3
+        accept_event = event_creator.get_create_review_event(
+            senior_detective1.id, item3.id)
+        app.create_review(accept_event, None, True, session)
+        open_item_after_accept = operations.get_open_items_for_user_db(
+            senior_detective1, 5, True, session)
+        assert len(open_item_after_accept) == 1
+
+        item3 = operations.get_item_by_id(item3.id, True, session)
+        assert item3.in_progress_reviews_level_2 == 1
+
+        # Accepting event again
+        app.create_review(accept_event, None, True, session)
+        item3 = operations.get_item_by_id(item3.id, True, session)
+        assert item3.in_progress_reviews_level_2 == 1
+
+        # SeniorDetective 1 finishing review
+        review_event = event_creator.get_review_event(
+            item3.id, senior_detective1.id, 1)
+        app.submit_review(review_event, None, True, session)
+
+        open_items_for_senior = operations.get_open_items_for_user_db(
+            senior_detective1, 5, True, session)
+        assert len(open_items_for_senior) == 3
+
+        # JuniorDetective 1 reviewing item 3
+        accept_event = event_creator.get_create_review_event(
+            junior_detective1.id, item3.id)
+        app.create_review(accept_event, None, True, session)
+
+        open_item_after_accept = operations.get_open_items_for_user_db(
+            junior_detective1, 5, True, session)
+        assert len(open_item_after_accept) == 1
+
+        review_event = event_creator.get_review_event(
+            item3.id, junior_detective1.id, 1)
+        app.submit_review(review_event, None, True, session)
+
+        # For JuniorDetective1 only 3 cases should be available
+        open_items_after_submission = operations.get_open_items_for_user_db(
+            junior_detective1, 5, True, session)
+        assert len(open_items_after_submission) == 2
+

--- a/lambda_functions/test/unit/test_GetOpenItemsForUser.py
+++ b/lambda_functions/test/unit/test_GetOpenItemsForUser.py
@@ -70,7 +70,7 @@ class TestGetOpenItems:
         item1 = operations.get_item_by_id(item1.id, True, session)
         assert item1.in_progress_reviews_level_1 == 1
 
-        # Accepting event again
+        # Accepting event again should not create a new review
         app.create_review(accept_event, None, True, session)
         item1 = operations.get_item_by_id(item1.id, True, session)
         assert item1.in_progress_reviews_level_1 == 1
@@ -156,7 +156,7 @@ class TestGetOpenItems:
         item3 = operations.get_item_by_id(item3.id, True, session)
         assert item3.in_progress_reviews_level_2 == 1
 
-        # Accepting event again
+        # Accepting event again should not create a new review
         app.create_review(accept_event, None, True, session)
         item3 = operations.get_item_by_id(item3.id, True, session)
         assert item3.in_progress_reviews_level_2 == 1
@@ -183,8 +183,8 @@ class TestGetOpenItems:
             item3.id, junior_detective1.id, 1)
         app.submit_review(review_event, None, True, session)
 
-        # For JuniorDetective1 only 3 cases should be available
+        # For JuniorDetective1 only 2 cases should be available,
+        # because Item 1,2 and 3 were reviewed
         open_items_after_submission = operations.get_open_items_for_user_db(
             junior_detective1, 5, True, session)
         assert len(open_items_after_submission) == 2
-


### PR DESCRIPTION
Preisfrage: Warum funktioniert diese Query für den Junior Detective aber die entsprechende nicht für den Senior Detective?
    result = session.query(Item) \
        .filter(Item.open_reviews_level_1 > Item.in_progress_reviews_level_1) \
        .filter(~Item.review_pairs.any(Review.user_id == user.id)) \
        .order_by(Item.open_timestamp.asc()) \
        .limit(num_items).all()
