### PR TITLE
Hotfix/cors header no origin

### DIFF
--- a/lambda_layers/core_layer/python/core_layer/helper.py
+++ b/lambda_layers/core_layer/python/core_layer/helper.py
@@ -53,7 +53,7 @@ def set_cors(response, event, is_test):
     source_origin = None
     allowed_origins = os.environ['CORS_ALLOW_ORIGIN'].split(',')
 
-    if 'headers' in event:
+    if 'headers' in event and event['headers'] is not None:
         if 'Origin' in event['headers']:
             source_origin = event['headers']['Origin']
         if 'origin' in event['headers']:

--- a/lambda_layers/core_layer/python/core_layer/test/test_cors_helper.py
+++ b/lambda_layers/core_layer/python/core_layer/test/test_cors_helper.py
@@ -1,0 +1,57 @@
+from core_layer.helper import set_cors
+
+
+def test_set_cors_header_no_origin(monkeypatch):
+
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN", "http://localhost:4200")
+    event = {'headers': None}
+    response = {}
+
+    response = set_cors(response, event, False)
+
+
+def test_set_cors_header_simple(monkeypatch):
+
+    origin = "http://localhost:4200"
+
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN", origin)
+    event = {'headers': {'Origin': origin}}
+    response = {}
+
+    response = set_cors(response, event, False)
+
+    assert response['headers']['Access-Control-Allow-Origin'] == origin
+
+
+def test_set_cors_header_non_capital(monkeypatch):
+
+    origin = "http://localhost:4200"
+
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN", origin)
+    event = {'headers': {'origin': origin}}
+    response = {}
+
+    response = set_cors(response, event, False)
+
+    assert response['headers']['Access-Control-Allow-Origin'] == origin
+
+
+def test_set_cors_header_multiple_allowed(monkeypatch):
+
+    origin = "http://localhost:4200"
+    origin2 = "http://localhost:4201"
+
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN", f'{origin},{origin2}')
+    event = {'headers': {'origin': origin}}
+    response = {}
+
+    response = set_cors(response, event, False)
+
+    assert response['headers']['Access-Control-Allow-Origin'] == origin
+
+    event2 = {'headers': {'origin': origin2}}
+    response2 = {}
+
+    response2 = set_cors(response2, event2, False)
+
+    assert response2['headers']['Access-Control-Allow-Origin'] == origin2


### PR DESCRIPTION
This should allow testing the API Gateway without having to provide the origin.