### PR TITLE
SearchFactChecks: No module named 'core_layer'

### DIFF
--- a/lambda_functions/ml_service/template.yaml
+++ b/lambda_functions/ml_service/template.yaml
@@ -97,6 +97,7 @@ Resources:
       Runtime: python3.8
       MemorySize: 832
       Layers:
+        - !Sub "arn:aws:lambda:eu-central-1:891514678401:layer:detektivkollektiv-core-layer-${STAGE}:1"
         - !Sub "arn:aws:lambda:eu-central-1:891514678401:layer:detektivkollektiv-ml-requirements-${STAGE}:1"
       Role:
         Fn::GetAtt:


### PR DESCRIPTION
"from core_layer.helper import get_google_api_key" requires core-layer in template.yaml