### PR TITLE
Feature/plugin_cors_adaption

### DIFF
--- a/lambda_functions/archive_service/get_closed_items.py
+++ b/lambda_functions/archive_service/get_closed_items.py
@@ -15,9 +15,11 @@ def get_closed_items(event, context):
     helper.log_method_initiated("Get all closed items", event, logger)
 
     with Session() as session:
+        plugin_call = False
         try:
             url = event["queryStringParameters"]['url']
             logger.info("Found url in queryparams")
+            plugin_call = True
         except:
             url = None
             logger.info("No url found in queryparams")
@@ -55,5 +57,5 @@ def get_closed_items(event, context):
                 "body": "Could not get closed items. Stacktrace: {}".format(traceback.format_exc())
             }
 
-    response_cors = helper.set_cors(response, event)
+    response_cors = helper.set_cors(response, event, plugin_call)
     return response_cors

--- a/lambda_functions/archive_service/get_closed_items.py
+++ b/lambda_functions/archive_service/get_closed_items.py
@@ -15,22 +15,16 @@ def get_closed_items(event, context):
     helper.log_method_initiated("Get all closed items", event, logger)
 
     with Session() as session:
-        plugin_call = False
-        try:
-            url = event["queryStringParameters"]['url']
-            logger.info("Found url in queryparams")
-            plugin_call = True
-        except:
-            url = None
-            logger.info("No url found in queryparams")
-            pass
 
         try:
             # Get all closed items
             print("\n \n \n Getting items \n \n \n")
+            allow_all_origins = False
 
-            if url:
-                items = item_handler.get_closed_items_by_url(url, session)
+            if 'queryStringParameters' in event and 'url' in event['queryStringParameters']:
+                items = item_handler.get_closed_items_by_url(
+                    event['queryStringParameters']['url'], session)
+                allow_all_origins = True
             else:
                 items = item_handler.get_all_closed_items(session)
 
@@ -57,5 +51,5 @@ def get_closed_items(event, context):
                 "body": "Could not get closed items. Stacktrace: {}".format(traceback.format_exc())
             }
 
-    response_cors = helper.set_cors(response, event, plugin_call)
+    response_cors = helper.set_cors(response, event, allow_all_origins)
     return response_cors

--- a/lambda_functions/archive_service/tests/unit/test_get_closed_items.py
+++ b/lambda_functions/archive_service/tests/unit/test_get_closed_items.py
@@ -94,7 +94,7 @@ def test_get_items_by_url():
         session.commit()
 
         # Testing get_items without url query param 204
-        response = get_closed_items(None, None)
+        response = get_closed_items({}, None)
         assert response['statusCode'] == 200
         body = json.loads(response['body'])
         assert len(body) == 2

--- a/lambda_layers/core_layer/python/core_layer/helper.py
+++ b/lambda_layers/core_layer/python/core_layer/helper.py
@@ -39,7 +39,7 @@ def get_date_time_str(dt):
         return dt
 
 
-def set_cors(response, event):
+def set_cors(response, event, plugin_call=False):
     """Adds a CORS header to a response according to the headers found in the event.
 
     Parameters
@@ -66,7 +66,7 @@ def set_cors(response, event):
         if 'origin' in event['headers']:
             source_origin = event['headers']['origin']
 
-        if source_origin and source_origin in allowed_origins:
+        if source_origin and (source_origin in allowed_origins or plugin_call):
             if 'headers' not in response:
                 response['headers'] = {}
 

--- a/lambda_layers/core_layer/python/core_layer/helper.py
+++ b/lambda_layers/core_layer/python/core_layer/helper.py
@@ -39,7 +39,7 @@ def get_date_time_str(dt):
         return dt
 
 
-def set_cors(response, event, plugin_call=False):
+def set_cors(response, event, allow_all_origins=False):
     """Adds a CORS header to a response according to the headers found in the event.
 
     Parameters
@@ -48,6 +48,9 @@ def set_cors(response, event, plugin_call=False):
         The response to be modified
     event: dict
         The Lambda event
+    allow_all_origins: bool, default False
+        If this param is set True, the check for the 'CORS_ALLOW_ORIGIN' environment variable 
+        will be omitted and the header will be set for any origin
 
     Returns
     ------
@@ -66,7 +69,7 @@ def set_cors(response, event, plugin_call=False):
         if 'origin' in event['headers']:
             source_origin = event['headers']['origin']
 
-        if source_origin and (source_origin in allowed_origins or plugin_call):
+        if source_origin and (source_origin in allowed_origins or allow_all_origins):
             if 'headers' not in response:
                 response['headers'] = {}
 

--- a/lambda_layers/core_layer/python/core_layer/test/test_cors_helper.py
+++ b/lambda_layers/core_layer/python/core_layer/test/test_cors_helper.py
@@ -1,7 +1,13 @@
 from core_layer.helper import set_cors
+import pytest
 
 
-def test_set_cors_header_no_origin(monkeypatch):
+@pytest.fixture
+def set_deployment_mode(monkeypatch):
+    monkeypatch.setattr('core_layer.helper.is_test', False)
+
+
+def test_set_cors_header_no_origin(monkeypatch, mock_deployment):
 
     monkeypatch.setenv("CORS_ALLOW_ORIGIN", "http://localhost:4200")
     event = {'headers': None}
@@ -10,7 +16,7 @@ def test_set_cors_header_no_origin(monkeypatch):
     response = set_cors(response, event)
 
 
-def test_set_cors_header_simple(monkeypatch):
+def test_set_cors_header_simple(monkeypatch, set_deployment_mode):
 
     origin = "http://localhost:4200"
 
@@ -23,7 +29,7 @@ def test_set_cors_header_simple(monkeypatch):
     assert response['headers']['Access-Control-Allow-Origin'] == origin
 
 
-def test_set_cors_header_non_capital(monkeypatch):
+def test_set_cors_header_non_capital(monkeypatch, set_deployment_mode):
 
     origin = "http://localhost:4200"
 
@@ -36,7 +42,7 @@ def test_set_cors_header_non_capital(monkeypatch):
     assert response['headers']['Access-Control-Allow-Origin'] == origin
 
 
-def test_set_cors_header_multiple_allowed(monkeypatch):
+def test_set_cors_header_multiple_allowed(monkeypatch, set_deployment_mode):
 
     origin = "http://localhost:4200"
     origin2 = "http://localhost:4201"
@@ -55,3 +61,18 @@ def test_set_cors_header_multiple_allowed(monkeypatch):
     response2 = set_cors(response2, event2)
 
     assert response2['headers']['Access-Control-Allow-Origin'] == origin2
+
+
+def test_set_cors_header_plugin(monkeypatch, set_deployment_mode):
+
+    origin = "http://www.spiegel.de"
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN", '')
+
+    event = {'headers': {'origin': origin}}
+
+    response = set_cors({}, event, True)
+
+    assert response['headers']['Access-Control-Allow-Origin'] == origin
+
+    response2 = set_cors({}, event)
+    assert 'headers' not in response2

--- a/lambda_layers/core_layer/python/core_layer/test/test_cors_helper.py
+++ b/lambda_layers/core_layer/python/core_layer/test/test_cors_helper.py
@@ -7,7 +7,7 @@ def set_deployment_mode(monkeypatch):
     monkeypatch.setattr('core_layer.helper.is_test', False)
 
 
-def test_set_cors_header_no_origin(monkeypatch, mock_deployment):
+def test_set_cors_header_no_origin(monkeypatch, set_deployment_mode):
 
     monkeypatch.setenv("CORS_ALLOW_ORIGIN", "http://localhost:4200")
     event = {'headers': None}


### PR DESCRIPTION
Problem: Die Origin der API Requests eines Browserplugins kommen immer von der Seite auf der sich der User momentan befindet.
Lösung: In diesem Fall (/items mit URL als query param) wird die Prüfung der origin mit den allowed origins aus den Umgebungsvariablen deaktiviert 