### PR TITLE
Get closed Item by URL: Query Parameter ignorieren 

### DIFF
--- a/lambda_functions/archive_service/get_closed_items.py
+++ b/lambda_functions/archive_service/get_closed_items.py
@@ -22,8 +22,10 @@ def get_closed_items(event, context):
             allow_all_origins = False
 
             if 'queryStringParameters' in event and isinstance(event['queryStringParameters'], dict) and 'url' in event['queryStringParameters']:
+                url_without_query_params = event['queryStringParameters']['url'].split('?')[
+                    0]
                 items = item_handler.get_closed_items_by_url(
-                    event['queryStringParameters']['url'], session)
+                    url_without_query_params, session)
                 allow_all_origins = True
             else:
                 items = item_handler.get_all_closed_items(session)

--- a/lambda_functions/archive_service/tests/unit/test_get_closed_items.py
+++ b/lambda_functions/archive_service/tests/unit/test_get_closed_items.py
@@ -83,7 +83,7 @@ def test_get_items_by_url():
 
         url = URL()
         url.id = "url_id"
-        url.url = "www.test.de"
+        url.url = "www.test.de/artikel1"
 
         item_url = ItemURL()
         item_url.id = "item_url_id"
@@ -101,20 +101,22 @@ def test_get_items_by_url():
             assert len(body) == 2
 
         # Testing get_items with url query param 200
-        response = get_closed_items(get_url_event(url.url), None)
-        assert response['statusCode'] == 200
-        body = json.loads(response['body'])
-        assert len(body) == 1
-        assert body[0]['id'] == item.id
+        for url in [url.url, url.url+'?queryparam=shouldbeignored']:
+            response = get_closed_items(get_url_event(url), None)
+            assert response['statusCode'] == 200
+            body = json.loads(response['body'])
+            assert len(body) == 1
+            assert body[0]['id'] == item.id
 
         # Testing get_items with url query param 204 - no item with url
-        response = get_closed_items(get_url_event("SinnloseUrl"), None)
-        assert response['statusCode'] == 204
+        for url in ['sinnloseUrl', 'www.test.de/artikel2', 'www.test.de']:
+            response = get_closed_items(get_url_event(url), None)
+            assert response['statusCode'] == 204
 
         # Testing get_items with url query param 204 - item not closed
         item.status = "open"
         session.merge(item)
         session.commit()
-
-        response = get_closed_items(get_url_event(url.url), None)
+        response = get_closed_items(
+            get_url_event("www.test.de/artikel1"), None)
         assert response['statusCode'] == 204

--- a/lambda_layers/core_layer/python/core_layer/db_handler.py
+++ b/lambda_layers/core_layer/python/core_layer/db_handler.py
@@ -35,14 +35,6 @@ session_factory = sessionmaker(bind=db, expire_on_commit=False, autoflush=True)
 Session = scoped_session(session_factory)
 
 
-def substring(column, delimeter, session):
-    if session.bind.dialect.name == 'sqlite':
-        return func.iif(func.instr(column, delimeter) > 0, func.substr(
-            column, 1, func.instr(column, delimeter)-1), column)
-    elif session.bind.dialect.name == 'mysql+auroradataapi':
-        return func.substring_index(column, delimeter, 1)
-
-
 def update_object(obj, session):
     """Updates an existing item in the database.
 

--- a/lambda_layers/core_layer/python/core_layer/db_helper.py
+++ b/lambda_layers/core_layer/python/core_layer/db_helper.py
@@ -1,0 +1,9 @@
+from sqlalchemy import func
+
+
+def substring(column, delimeter, session):
+    if session.bind.dialect.name == 'sqlite':
+        return func.iif(func.instr(column, delimeter) > 0, func.substr(
+            column, 1, func.instr(column, delimeter)-1), column)
+    elif session.bind.dialect.name == 'mysql+auroradataapi':
+        return func.substring_index(column, delimeter, 1)

--- a/lambda_layers/core_layer/python/core_layer/handler/item_handler.py
+++ b/lambda_layers/core_layer/python/core_layer/handler/item_handler.py
@@ -8,6 +8,7 @@ from core_layer.model.review_model import Review
 from core_layer.model.url_model import URL, ItemURL
 from core_layer.handler import review_pair_handler, review_handler
 from uuid import uuid4
+from core_layer import db_handler
 
 
 def get_all_items(session, params: dict = {}) -> List[Item]:
@@ -181,5 +182,5 @@ def compute_item_result_score(item_id, session):
 
 def get_closed_items_by_url(url, session) -> List[Item]:
     items = session.query(Item).filter(Item.status == "closed").join(Item.urls).join(
-        ItemURL.url).filter_by(url=url).all()
+        ItemURL.url).filter(db_handler.substring(URL.url, '?', session) == url).all()
     return items

--- a/lambda_layers/core_layer/python/core_layer/handler/item_handler.py
+++ b/lambda_layers/core_layer/python/core_layer/handler/item_handler.py
@@ -8,7 +8,7 @@ from core_layer.model.review_model import Review
 from core_layer.model.url_model import URL, ItemURL
 from core_layer.handler import review_pair_handler, review_handler
 from uuid import uuid4
-from core_layer import db_handler
+from core_layer import db_helper
 
 
 def get_all_items(session, params: dict = {}) -> List[Item]:
@@ -182,5 +182,5 @@ def compute_item_result_score(item_id, session):
 
 def get_closed_items_by_url(url, session) -> List[Item]:
     items = session.query(Item).filter(Item.status == "closed").join(Item.urls).join(
-        ItemURL.url).filter(db_handler.substring(URL.url, '?', session) == url).all()
+        ItemURL.url).filter(db_helper.substring(URL.url, '?', session) == url).all()
     return items


### PR DESCRIPTION
- Damit das Browser-Plugin bessere Trefferquoten erzielen kann, werden die Queryparameter der URLs in der DB und der eingehenden Requests ignoriert
- Da SQLite keine "substring" funktion beinhaltet, habe ich eine Extra Methode fürs Testing im DB Handler gebaut. Auf dev muss nochmal getestet werden, ob die Query auch im mysql-aurora dialekt funktioniert