### PR TITLE
Feature/fix_date_issue

### DIFF
--- a/lambda_functions/submission_service/tests/unit/test_mail_anonymization.py
+++ b/lambda_functions/submission_service/tests/unit/test_mail_anonymization.py
@@ -10,8 +10,7 @@ from core_layer import helper
 
 @pytest.fixture
 def submission1():
-    three_days_ago = helper.get_date_time(
-        datetime.now() - timedelta(days=3))
+    three_days_ago = datetime.now() - timedelta(days=3)
 
     submission = Submission()
     submission.id = str(uuid4())

--- a/lambda_functions/user_service/tests/unit/test_get_user.py
+++ b/lambda_functions/user_service/tests/unit/test_get_user.py
@@ -34,7 +34,7 @@ def test_get_user():
         assert body["solved_cases_today"] == 0
         assert body["exp_needed"] == 5
         sign_up_date = datetime.strptime(
-            body["sign_up_timestamp"], '%Y-%m-%d %H:%M:%S').date()
+            body["sign_up_timestamp"], '%Y-%m-%dT%H:%M:%S').date()
         assert sign_up_date != datetime.today()
 
         item1 = Item(id='item1', status='closed')

--- a/lambda_layers/core_layer/python/core_layer/handler/review_handler.py
+++ b/lambda_layers/core_layer/python/core_layer/handler/review_handler.py
@@ -1,4 +1,6 @@
 from uuid import uuid4
+from datetime import datetime, timedelta
+
 import random
 from sqlalchemy import or_
 from core_layer.db_handler import update_object
@@ -81,8 +83,6 @@ def create_review(user, item, session) -> Review:
     rip.id = str(uuid4())
     rip.item_id = item.id
     rip.user_id = user.id
-    rip.start_timestamp = helper.get_date_time_now()
-    rip.status = "in_progress"
     session.add(rip)
     session.commit()
 
@@ -157,7 +157,7 @@ def compute_review_result(review_answers):
 
 
 def get_old_reviews_in_progress(session):
-    old_time = helper.get_date_time_one_hour_ago()
+    old_time = datetime.now() + timedelta(hours=-1)
     rips = session.query(Review).filter(
         Review.start_timestamp < old_time, Review.status == "in_progress").all()
     return rips
@@ -215,7 +215,7 @@ def create_answers_for_review(review: Review, session):
 
 def close_review(review: Review, session) -> Review:
     review.status = "closed"
-    review.finish_timestamp = helper.get_date_time_now()
+    review.finish_timestamp = datetime.now()
     user_handler.give_experience_point(review.user_id, session)
 
     pair = review_pair_handler.get_review_pair_from_review(review, session)

--- a/lambda_layers/core_layer/python/core_layer/handler/submission_handler.py
+++ b/lambda_layers/core_layer/python/core_layer/handler/submission_handler.py
@@ -22,7 +22,6 @@ def create_submission_db(submission, session):
     """
 
     submission.id = str(uuid4())
-    submission.submission_date = helper.get_date_time_now()
 
     session.add(submission)
     session.commit()
@@ -49,7 +48,7 @@ def confirm_submission(submission_id, session):
 
 def anonymize_unconfirmed_submissions(session):
 
-    two_days_ago = helper.get_date_time(datetime.now() - timedelta(days=2))
+    two_days_ago = datetime.now() - timedelta(days=2)
     submissions = session.query(Submission).filter(
         Submission.status == 'unconfirmed', Submission.submission_date < two_days_ago).all()
     counter = 0

--- a/lambda_layers/core_layer/python/core_layer/handler/tests/unit/helper/review_creator.py
+++ b/lambda_layers/core_layer/python/core_layer/handler/tests/unit/helper/review_creator.py
@@ -1,9 +1,8 @@
 from core_layer.model import Review
-from core_layer.helper import get_date_time, get_date_time_now
 from datetime import datetime
 
 
-def create_review(id: int, item_id: str, user_id: str=None, status: str=None, finish_time=None) -> Review:
+def create_review(id: int, item_id: str, user_id: str = None, status: str = None, finish_time=None) -> Review:
     review = Review()
 
     review.id = id
@@ -11,8 +10,8 @@ def create_review(id: int, item_id: str, user_id: str=None, status: str=None, fi
     review.user_id = user_id
     review.status = status
     if finish_time == None:
-        review.finish_timestamp = get_date_time_now()
+        review.finish_timestamp = datetime.now()
     else:
-        review.finish_timestamp = get_date_time(finish_time)
-        
+        review.finish_timestamp = finish_time
+
     return review

--- a/lambda_layers/core_layer/python/core_layer/handler/user_handler.py
+++ b/lambda_layers/core_layer/python/core_layer/handler/user_handler.py
@@ -40,7 +40,7 @@ def delete_user(event, session):
     ------
     nothing
     """
-   
+
     user_id = helper.cognito_id_from_event(event)
     user = session.query(User).get(user_id)
 
@@ -72,7 +72,7 @@ def create_user(user, session):
     user: User
         The inserted user
     """
-    
+
     session.add(user)
     session.commit()
 
@@ -142,7 +142,7 @@ def get_top_users_by_period(n, p, attr, descending, session) -> List[User]:
         A list including the top n user objects as ordered by attr, desc
     """
 
-    compare_timestamp = helper.get_date_time(datetime.now() - timedelta(weeks=p))
+    compare_timestamp = datetime.now() - timedelta(weeks=p)
     sort_column = getattr(User, attr).desc(
     ) if descending else getattr(User, attr)
 
@@ -175,7 +175,7 @@ def get_top_users_by_level(user_level, n, attr, descending, session) -> List[Use
     users: [User]
         A list including the top n user objects as ordered by attr, desc
     """
-    
+
     sort_column = getattr(User, attr).desc(
     ) if descending else getattr(User, attr)
 

--- a/lambda_layers/core_layer/python/core_layer/helper.py
+++ b/lambda_layers/core_layer/python/core_layer/helper.py
@@ -10,35 +10,6 @@ from sqlalchemy import func
 is_test = 'DEPLOYMENTMODE' not in os.environ
 
 
-def get_date_time_now():
-    return func.now()
-    # TODO: Remove this method. Use func.now() and set create_time in model
-    # https://stackoverflow.com/questions/13370317/sqlalchemy-default-datetime
-    # TODO: Update to newer version of Sqlalchemy Aurora Library and adapt datemanagement accordingly
-
-
-def get_date_time_one_hour_ago():
-    dt = datetime.now() + timedelta(hours=-1)
-    if is_test:
-        return dt
-    else:
-        return dt.strftime('%Y-%m-%d %H:%M:%S')
-
-
-def get_date_time(dt):
-    if is_test:
-        return dt
-    else:
-        return dt.strftime('%Y-%m-%d %H:%M:%S')
-
-
-def get_date_time_str(dt):
-    if isinstance(dt, datetime):
-        return dt.strftime('%Y-%m-%d %H:%M:%S')
-    else:
-        return dt
-
-
 def set_cors(response, event, allow_all_origins=False):
     """Adds a CORS header to a response according to the headers found in the event.
 

--- a/lambda_layers/core_layer/python/core_layer/model/comment_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/comment_model.py
@@ -45,7 +45,7 @@ class Comment(Base):
     def to_dict(self) -> dict:
         return {
             "id": self.id,
-            "timestamp": self.timestamp.strftime('%Y-%m-%d %H:%M:%S') if isinstance(self.timestamp, datetime) else self.timestamp,
+            "timestamp": self.timestamp.isoformat(),
             'comment': self.comment,
             'is_review_comment': str(self.is_review_comment),
             'user': self.user.name if self.user else None

--- a/lambda_layers/core_layer/python/core_layer/model/comment_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/comment_model.py
@@ -45,7 +45,7 @@ class Comment(Base):
     def to_dict(self) -> dict:
         return {
             "id": self.id,
-            "timestamp": self.timestamp.isoformat(),
+            "timestamp": self.timestamp.isoformat() if self.timestamp else "" if self.timestamp else "",
             'comment': self.comment,
             'is_review_comment': str(self.is_review_comment),
             'user': self.user.name if self.user else None

--- a/lambda_layers/core_layer/python/core_layer/model/item_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/item_model.py
@@ -59,8 +59,8 @@ class Item(Base):
             "open_reviews": self.open_reviews,
             "in_progress_reviews_level_1": self.in_progress_reviews_level_1,
             "in_progress_reviews_level_2": self.in_progress_reviews_level_2,
-            "open_timestamp": self.open_timestamp.isoformat(),
-            "close_timestamp": self.close_timestamp.isoformat()
+            "open_timestamp": self.open_timestamp.isoformat() if self.open_timestamp else "",
+            "close_timestamp": self.close_timestamp.isoformat() if self.close_timestamp else ""
         }
 
         if with_tags:

--- a/lambda_layers/core_layer/python/core_layer/model/item_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/item_model.py
@@ -59,8 +59,8 @@ class Item(Base):
             "open_reviews": self.open_reviews,
             "in_progress_reviews_level_1": self.in_progress_reviews_level_1,
             "in_progress_reviews_level_2": self.in_progress_reviews_level_2,
-            "open_timestamp": self.open_timestamp.strftime('%Y-%m-%d %H:%M:%S') if isinstance(self.open_timestamp, datetime) else self.open_timestamp,
-            "close_timestamp": self.close_timestamp.strftime('%Y-%m-%d %H:%M:%S') if isinstance(self.close_timestamp, datetime) else self.close_timestamp
+            "open_timestamp": self.open_timestamp.isoformat(),
+            "close_timestamp": self.close_timestamp.isoformat()
         }
 
         if with_tags:

--- a/lambda_layers/core_layer/python/core_layer/model/review_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/review_model.py
@@ -13,9 +13,9 @@ class Review(Base):
     user_id = Column(String(36), ForeignKey('users.id'))
     item_id = Column(String(36), ForeignKey('items.id',
                                             ondelete='CASCADE', onupdate='CASCADE'))
-    start_timestamp = Column(DateTime)
+    start_timestamp = Column(DateTime, server_default=func.now())
     finish_timestamp = Column(DateTime)
-    status = Column(String(100))
+    status = Column(String(100), default="in_progress")
 
     review_answers = relationship(
         "ReviewAnswer", back_populates="review", lazy="joined")

--- a/lambda_layers/core_layer/python/core_layer/model/review_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/review_model.py
@@ -30,8 +30,8 @@ class Review(Base):
             "is_peer_review": self.is_peer_review,
             "belongs_to_good_pair": self.belongs_to_good_pair,
             "user_id": self.user_id,
-            "start_timestamp": self.start_timestamp.isoformat(),
-            "finish_timestamp": self.finish_timestamp.isoformat()
+            "start_timestamp": self.start_timestamp.isoformat() if self.start_timestamp else "",
+            "finish_timestamp": self.finish_timestamp.isoformat() if self.finish_timestamp else ""
         }
         return_dict['comment'] = self.comment.comment if self.comment else None
         if with_questions_and_answers:

--- a/lambda_layers/core_layer/python/core_layer/model/review_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/review_model.py
@@ -30,8 +30,8 @@ class Review(Base):
             "is_peer_review": self.is_peer_review,
             "belongs_to_good_pair": self.belongs_to_good_pair,
             "user_id": self.user_id,
-            "start_timestamp": str(self.start_timestamp),
-            "finish_timestamp": str(self.finish_timestamp)
+            "start_timestamp": self.start_timestamp.isoformat(),
+            "finish_timestamp": self.finish_timestamp.isoformat()
         }
         return_dict['comment'] = self.comment.comment if self.comment else None
         if with_questions_and_answers:

--- a/lambda_layers/core_layer/python/core_layer/model/submission_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/submission_model.py
@@ -23,13 +23,13 @@ class Submission(Base):
     def to_dict(self):
         return {
             "id": self.id,
-            "submission_date": self.submission_date,
+            "submission_date": self.submission_date.isoformat(),
             "mail": self.mail,
             "telegram_id": self.telegram_id,
             "phone": self.phone,
             "source": self.source,
             "frequency": self.frequency,
-            "received_date": self.received_date,
+            "received_date": self.received_date.isoformat(),
             "item_id": self.item_id,
             "status": self.status
         }

--- a/lambda_layers/core_layer/python/core_layer/model/submission_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/submission_model.py
@@ -6,7 +6,7 @@ from .model_base import Base
 class Submission(Base):
     __tablename__ = 'submissions'
     id = Column(String(36), primary_key=True)
-    submission_date = Column(DateTime)
+    submission_date = Column(DateTime, server_default=func.now())
     mail = Column(String(100))
     telegram_id = Column(String(100))
     phone = Column(String(36))

--- a/lambda_layers/core_layer/python/core_layer/model/submission_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/submission_model.py
@@ -23,13 +23,13 @@ class Submission(Base):
     def to_dict(self):
         return {
             "id": self.id,
-            "submission_date": self.submission_date.isoformat(),
+            "submission_date": self.submission_date.isoformat() if self.submission_date else "",
             "mail": self.mail,
             "telegram_id": self.telegram_id,
             "phone": self.phone,
             "source": self.source,
             "frequency": self.frequency,
-            "received_date": self.received_date.isoformat(),
+            "received_date": self.received_date.isoformat() if self.received_date else "",
             "item_id": self.item_id,
             "status": self.status
         }

--- a/lambda_layers/core_layer/python/core_layer/model/user_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/user_model.py
@@ -27,5 +27,5 @@ class User(Base):
             "level": self.level_id,
             "level_description": self.level.description,
             "experience_points": self.experience_points,
-            "sign_up_timestamp": str(self.sign_up_timestamp)
+            "sign_up_timestamp": self.sign_up_timestamp.isoformat()
         }

--- a/lambda_layers/core_layer/python/core_layer/model/user_model.py
+++ b/lambda_layers/core_layer/python/core_layer/model/user_model.py
@@ -27,5 +27,5 @@ class User(Base):
             "level": self.level_id,
             "level_description": self.level.description,
             "experience_points": self.experience_points,
-            "sign_up_timestamp": self.sign_up_timestamp.isoformat()
+            "sign_up_timestamp": self.sign_up_timestamp.isoformat() if self.sign_up_timestamp else ""
         }

--- a/lambda_layers/core_layer/python/core_layer/test/test_item_model.py
+++ b/lambda_layers/core_layer/python/core_layer/test/test_item_model.py
@@ -62,6 +62,7 @@ def test_item_model_to_dict_with_reviews(item_id, review_id, review_answer_id, u
         assert len(item_dict['users']) == 1
         assert item_dict['users'][0]['username'] == 'testuser'
         assert item_dict['users'][0]['level_description'] == 'beginner'
+        assert 'T' in item_dict['open_timestamp']
 
         session.delete(user)
         session.expire_all()

--- a/lambda_layers/core_layer/requirements.txt
+++ b/lambda_layers/core_layer/requirements.txt
@@ -1,4 +1,4 @@
 sqlalchemy
-sqlalchemy-aurora-data-api==0.2.0
+sqlalchemy-aurora-data-api==0.3.4
 boto3~=1.10.14
 botocore~=1.13.14


### PR DESCRIPTION
Habe die Version der Dependency für die Aurora Data API erhöht. 
Die neue Version arbeitet jetzt mit Datetime-Objekten statt mit Strings, weshalb die Unterscheidung zwischen str und datetime für test und prod jetzt wegfällt. 

Damit wir im Frontend nicht mehr das Datumsformat korrigieren müssen, habe ich in den to_dict-Methoden jeweils die .isoformat()-Methode eingefügt bei den Daten. Damit werden sie mit dem 'T' als Separator ausgegeben. 
Das Datumsformat in der Datenbank ist das Standard MySQL Datenformat - Das sollten wir nicht ändern und müssen wir mit dieser Lösung auch gar nicht. 

Nach dem Merge sollten wir das ganze auf dev nochmal ausführlich testen.