### PR TITLE
Bugfix/create user email duplicate entry

### DIFF
--- a/lambda_functions/tests/integration/test_double_opt_in.py
+++ b/lambda_functions/tests/integration/test_double_opt_in.py
@@ -40,7 +40,7 @@ def test_double_opt_in(mail_address, monkeypatch):
 
         # Confirm subscription 
         event = {'pathParameters': {'mail_id': mail.id}}
-        response = mail_subscription.confirm_mail_subscription(event)
+        response = mail_subscription.confirm_mail_subscription(event, context = "")
 
         # Check response
         assert response['statusCode'] == 200

--- a/lambda_functions/user_service/create_user.py
+++ b/lambda_functions/user_service/create_user.py
@@ -7,7 +7,7 @@ from core_layer.model.mail_model import Mail
 from core_layer.handler import user_handler, mail_handler
 
 
-def create_user(event):
+def create_user(event, context):
 
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)

--- a/lambda_functions/user_service/delete_unconfirmed_mails.py
+++ b/lambda_functions/user_service/delete_unconfirmed_mails.py
@@ -7,7 +7,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def delete_unconfirmed_mails(event):
+def delete_unconfirmed_mails(event, context):
 
     helper.log_method_initiated("Delete unconfirmed mails", event, logger)
 

--- a/lambda_functions/user_service/mail_subscription.py
+++ b/lambda_functions/user_service/mail_subscription.py
@@ -10,7 +10,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def confirm_mail_subscription(event):
+def confirm_mail_subscription(event, context):
 
     helper.log_method_initiated("Confirm mail subscription", event, logger)
 
@@ -47,7 +47,7 @@ def confirm_mail_subscription(event):
         return helper.set_cors(response, event)
 
 
-def unsubscribe_mail(event):
+def unsubscribe_mail(event, context):
 
     helper.log_method_initiated("Unsubscribe mail", event, logger)
 

--- a/lambda_functions/user_service/tests/unit/test_delete_unconfirmed_mails.py
+++ b/lambda_functions/user_service/tests/unit/test_delete_unconfirmed_mails.py
@@ -42,7 +42,7 @@ def test_delete_unconfirmed_mails(mail1, mail2):
         assert len(mails) == 2
 
         # delete unconfirmed mails
-        delete_unconfirmed_mails(session)
+        delete_unconfirmed_mails(event = "", context = "")
         # check number of mails after deletion and verify 1 of 2 has been deleted
         mails = session.query(Mail).filter(
             Mail.status == "unconfirmed").all()

--- a/lambda_functions/user_service/tests/unit/test_mail_subscription.py
+++ b/lambda_functions/user_service/tests/unit/test_mail_subscription.py
@@ -49,11 +49,11 @@ def test_mail_subscription(user_id, mail_id, event, event_with_wrong_mail_id, mo
         # Check mail status
         assert session.query(Mail).first().status == "unconfirmed"
         # Confirm subscription
-        confirm_mail_subscription(event)
+        confirm_mail_subscription(event, context = "")
         assert session.query(Mail).first().status == "confirmed"
         # Unsubscribe
-        unsubscribe_mail(event)
+        unsubscribe_mail(event, context = "")
         assert session.query(Mail).first().status == "unsubscribed"
-        response = confirm_mail_subscription(event_with_wrong_mail_id)
+        response = confirm_mail_subscription(event_with_wrong_mail_id, context = "")
         body = response['body']
         assert 'Deine Mail-Adresse konnte nicht bestätigt werden' in body

--- a/lambda_layers/core_layer/python/core_layer/helper.py
+++ b/lambda_layers/core_layer/python/core_layer/helper.py
@@ -79,7 +79,7 @@ def body_to_object(body, object):
     return object
 
 
-def cognito_id_from_event(event):
+def cognito_id_from_event(event, context):
     """Extracts the cognito user id (=sub) from the event.
 
     Parameters
@@ -97,7 +97,7 @@ def cognito_id_from_event(event):
     return user_id
 
 
-def get_cognito_identity_from_event(event):
+def get_cognito_identity_from_event(event, context):
     """Extracts the current Cognito identity ID from the event.
 
     Parameters

--- a/lambda_layers/core_layer/python/core_layer/helper.py
+++ b/lambda_layers/core_layer/python/core_layer/helper.py
@@ -79,7 +79,7 @@ def body_to_object(body, object):
     return object
 
 
-def cognito_id_from_event(event, context):
+def cognito_id_from_event(event):
     """Extracts the cognito user id (=sub) from the event.
 
     Parameters
@@ -97,7 +97,7 @@ def cognito_id_from_event(event, context):
     return user_id
 
 
-def get_cognito_identity_from_event(event, context):
+def get_cognito_identity_from_event(event):
     """Extracts the current Cognito identity ID from the event.
 
     Parameters


### PR DESCRIPTION
- fix `Duplicate entry` bug that occured if a new user was created with a already existing mail address