### PR TITLE
add support mail address to mail sender

### DIFF
--- a/lambda_layers/core_layer/python/core_layer/sender/mail_sender.py
+++ b/lambda_layers/core_layer/python/core_layer/sender/mail_sender.py
@@ -63,6 +63,9 @@ class MailSender(NotificationSender):
                     'ToAddresses': [
                         RECIPIENT,
                     ],
+                    'BccAddresses': [
+                        'support@codetekt.org',
+                    ]
                 },
                 Message={
                     'Body': {


### PR DESCRIPTION
- Send mail to support@codetekt.org in BBC each time a notification mail is sent